### PR TITLE
Adding Ability to Extend Config with Additional Prefix Filtration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,17 +82,26 @@ $config->get('PHPFPM_BUFFER_COUNT'); // throws InvalidKeyException
 ```
 This becomes particularly useful when registering and referencing various configurations within, say, a container and services within the application are only interested in certain variables.
 
+The `withPrefix` method will take a given, "base" Configuration object and return a new one from it, applying another layer of filtering by prefix on from the keys in the base.
+
 ```php
-$container['config.debug'] = function () {
-	return new \Improv\Configuration($_ENV, 'APP_DEBUG_');
+$container['config.app'] = function () {
+	return new \Improv\Configuration($_ENV, 'APP_');
 };
 
-$container['config.db'] = function () {
-	return new \Improv\Configuration($_ENV, 'APP_DB_');
+$container['config.debug'] = function (Container $container) {
+    $base = $container->get('config.app');
+    return $base->withPrefix('DEBUG_');
 };
 
-$container['config.api'] = function () {
-	return new \Improv\Configuration($_ENV, 'APP_SOMESERVICE_API_');
+$container['config.db'] = function (Container $container) {
+	$base = $container->get('config.app');
+	return $base->withPrefix('DB_');
+};
+
+$container['config.api'] = function (Container $container) {
+    $base = $container->get('config.app');
+    return $base->withPrefix('SOMESERVICE_API_');
 };
 
 // ... //

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -14,6 +14,11 @@ class Configuration
     private $config;
 
     /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
      * @var MapperFactory
      */
     private $factory_mapper;
@@ -32,6 +37,7 @@ class Configuration
     {
 
         $this->config         = $config;
+        $this->prefix         = $prefix;
         $this->factory_mapper = ($mapper_factory) ?: new MapperFactory();
 
         if (!$prefix) {
@@ -107,6 +113,28 @@ class Configuration
         }
 
         return $this->config[$key];
+    }
+
+    /**
+     * Generates a new Configuration object from the current one, applying another layer of prefix filtration.
+     *
+     * @param string $prefix
+     *
+     * @return Configuration
+     */
+    public function withPrefix($prefix)
+    {
+        $config          = new self($this->config, $prefix, $this->factory_mapper);
+        $config->mappers = [];
+
+        foreach ($this->mappers as $key => $mapper) {
+            if (strpos($key, $prefix) !== 0) {
+                continue;
+            }
+            $config->mappers[str_replace($prefix, '', $key)] = $mapper;
+        }
+
+        return $config;
     }
 
     /**

--- a/tests/unit/ConfigurationTest.php
+++ b/tests/unit/ConfigurationTest.php
@@ -125,4 +125,40 @@ class ConfigurationTest extends AbstractTestCase
         self::assertSame('Mapped Value 2', $sut->get('KEY2'));
         self::assertSame('Mapped Value 3', $sut->get('KEY3'));
     }
+
+    /**
+     * @test
+     */
+    public function withPrefix()
+    {
+        $data = [
+            'OUTER_PREFIX_ONE'   => 'One',
+            'OUTER_PREFIX_TWO'   => 'Two',
+            'OUTER_THING'        => 'Thing',
+        ];
+
+        $original = new Configuration($data, 'OUTER_');
+
+        $original->map('PREFIX_TWO')->using(function ($val) {
+            return strrev(strtoupper($val));
+        });
+
+        $original->map('THING')->using(function ($val) {
+            return strrev(strtoupper($val));
+        });
+
+        self::assertSame('GNIHT', $original->get('THING'));
+
+        $sut = $original->withPrefix('PREFIX_');
+
+        self::assertInstanceOf(Configuration::class, $sut);
+
+        self::assertSame('One', $sut->get('ONE'));
+        self::assertSame('OWT', $sut->get('TWO'));
+
+        $this->expectException(InvalidKeyException::class);
+        $this->expectExceptionMessage('No such key "THING" exists in Config.');
+
+        $sut->get('THING');
+    }
 }


### PR DESCRIPTION
Adding `withPrefix($prefix)` to clone and provide additional filtration based on prefix.
